### PR TITLE
Update setup.py

### DIFF
--- a/cv_bridge/setup.py
+++ b/cv_bridge/setup.py
@@ -5,6 +5,6 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup()
 
 d['packages'] = ['cv_bridge']
-d['package_dir'] = {'' : 'python/'}
+d['package_dir'] = {'' : 'python'}
 
 setup(**d)


### PR DESCRIPTION
Build crashes on Windows when {'' : 'python/'} is used and not {'' : 'python'}